### PR TITLE
Fix AuthProvider context error and integrate real authentication

### DIFF
--- a/MyRiffsPage.tsx
+++ b/MyRiffsPage.tsx
@@ -159,12 +159,12 @@ const MyRiffsPage: React.FC = () => {
           <div className="flex flex-col md:flex-row items-center space-y-6 md:space-y-0 md:space-x-8">
             <div className="w-32 h-32 bg-white/20 backdrop-blur-sm rounded-full flex items-center justify-center">
               <span className="text-4xl font-bold">
-                {user.name.charAt(0).toUpperCase()}
+                {user?.user_metadata?.name?.charAt(0).toUpperCase() || user?.email?.charAt(0).toUpperCase() || 'U'}
               </span>
             </div>
             
             <div className="text-center md:text-left">
-              <h1 className="text-4xl md:text-5xl font-bold mb-2">{user.name}</h1>
+              <h1 className="text-4xl md:text-5xl font-bold mb-2">{user?.user_metadata?.name || user?.email?.split('@')[0] || 'User'}</h1>
               <p className="text-xl text-white/90 mb-4">AI Music Creator</p>
               <p className="text-white/80 max-w-2xl">
                 Passionate about creating unique AI-generated music that blends technology with creativity. 

--- a/SignInPage.tsx
+++ b/SignInPage.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Music, ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import type { Page } from './StrawberryRiffApp';
+import { useAuth } from './lib/AuthContext';
+
 interface SignInPageProps {
-  onSignIn: (email: string, password: string) => void;
+  onSignIn: () => void;
   onNavigate: (page: Page) => void;
 }
 const SignInPage: React.FC<SignInPageProps> = ({
@@ -14,15 +16,25 @@ const SignInPage: React.FC<SignInPageProps> = ({
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { signIn } = useAuth();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!email || !password) return;
+    
     setIsLoading(true);
-    // Simulate API call
-    setTimeout(() => {
-      onSignIn(email, password);
+    setError(null);
+    
+    const { error } = await signIn(email, password);
+    
+    if (error) {
+      setError(error.message);
       setIsLoading(false);
-    }, 1000);
+    } else {
+      onSignIn();
+      setIsLoading(false);
+    }
   };
   return <div className="min-h-screen flex items-center justify-center py-12 px-4 bg-gradient-to-br from-pink-50 via-purple-50 to-blue-50">
       <div className="max-w-md w-full">
@@ -60,6 +72,12 @@ const SignInPage: React.FC<SignInPageProps> = ({
             <h2 className="text-2xl font-bold text-gray-800 mb-2">Sign In</h2>
             <p className="text-gray-600">Continue your musical journey</p>
           </div>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg">
+              {error}
+            </div>
+          )}
 
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>

--- a/StrawberryRiffApp.tsx
+++ b/StrawberryRiffApp.tsx
@@ -10,29 +10,21 @@ import MyRiffsPage from './MyRiffsPage';
 import AboutContactPage from './AboutContactPage';
 import CreatorProfileFlow from './CreatorProfileFlow';
 import PricingPage from './PricingPage';
+import { useAuth } from './lib/AuthContext';
+
 export type Page = 'home' | 'upload' | 'friends' | 'playlists' | 'signin' | 'myriffs' | 'about' | 'profile-setup' | 'pricing';
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  avatar?: string;
-}
+
 const StrawberryRiffApp: React.FC = () => {
   const [currentPage, setCurrentPage] = useState<Page>('home');
-  const [user, setUser] = useState<User | null>(null);
-  const handleSignIn = (email: string, password: string) => {
-    // Mock authentication
-    setUser({
-      id: '1',
-      name: 'Music Creator',
-      email: email,
-      avatar: undefined
-    });
-    // Redirect new users to profile setup
+  const { user, signOut } = useAuth();
+
+  const handleSignIn = () => {
+    // Redirect new users to profile setup after successful sign in
     setCurrentPage('profile-setup');
   };
-  const handleSignOut = () => {
-    setUser(null);
+
+  const handleSignOut = async () => {
+    await signOut();
     setCurrentPage('home');
   };
   const renderPage = () => {
@@ -48,7 +40,7 @@ const StrawberryRiffApp: React.FC = () => {
       case 'signin':
         return <SignInPage onSignIn={handleSignIn} onNavigate={setCurrentPage} />;
       case 'myriffs':
-        return <MyRiffsPage user={user} />;
+        return <MyRiffsPage />;
       case 'about':
         return <AboutContactPage />;
       case 'pricing':
@@ -63,7 +55,7 @@ const StrawberryRiffApp: React.FC = () => {
     }
   };
   return <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-blue-50">
-      <AppHeader currentPage={currentPage} onNavigate={setCurrentPage} user={user} onSignOut={handleSignOut} />
+      <AppHeader currentPage={currentPage} onNavigate={setCurrentPage} onSignOut={handleSignOut} />
       
       <main className="pt-20">
         <AnimatePresence mode="wait">

--- a/main.tsx
+++ b/main.tsx
@@ -1,4 +1,9 @@
 import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import { AuthProvider } from './lib/AuthContext';
+
 // Force light mode by removing dark class and preventing it from being added
 document.documentElement.classList.remove('dark');
 
@@ -18,9 +23,11 @@ document.addEventListener('DOMContentLoaded', forceLightMode);
 // Override system preference changes
 const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 mediaQuery.addEventListener('change', forceLightMode);
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
-createRoot(document.getElementById('root')!).render(<StrictMode>
-    <App />
-  </StrictMode>);
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </StrictMode>
+);


### PR DESCRIPTION
# Fix AuthProvider context error and integrate real authentication

## Summary

This PR resolves the "Uncaught Error: useAuth must be used within an AuthProvider" runtime error that prevented the UI from rendering after Vercel deployment. The issue was caused by missing AuthProvider wrapper in the app root and conflicts between mock authentication and real Supabase authentication systems.

**Key Changes:**
- Added `AuthProvider` wrapper in `main.tsx` to provide authentication context to all components
- Removed mock authentication system from `StrawberryRiffApp.tsx` and integrated real Supabase authentication
- Updated component interfaces to work with Supabase `User` type instead of mock `User` interface
- Fixed `SignInPage` to use real authentication instead of mock sign-in flow
- Updated `MyRiffsPage` to access Supabase User properties (`user_metadata.name`, `email`)

## Review & Testing Checklist for Human

- [ ] **Test authentication flow end-to-end**: Sign up, sign in, sign out, and verify user state persists correctly
- [ ] **Verify Supabase environment configuration**: Ensure `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are properly set for production deployment
- [ ] **Test MyRiffsPage user display**: Verify user name, avatar, and profile information render correctly with Supabase User data
- [ ] **Test authenticated vs unauthenticated navigation**: Verify app behaves correctly when user is signed in vs signed out
- [ ] **Verify error handling**: Test sign-in with invalid credentials to ensure error messages display properly

**Recommended Test Plan:**
1. Deploy to Vercel and verify UI renders without console errors
2. Test complete user journey: sign up → profile setup → sign out → sign in → navigate to My Riffs page
3. Verify user data displays correctly throughout the app

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    mainTsx["main.tsx<br/>(App Entry Point)"]:::major-edit
    App["App.tsx"]:::context
    StrawberryRiffApp["StrawberryRiffApp.tsx<br/>(Main App Component)"]:::major-edit
    AuthContext["lib/AuthContext.tsx<br/>(Auth Provider)"]:::context
    SignInPage["SignInPage.tsx<br/>(Authentication)"]:::major-edit
    MyRiffsPage["MyRiffsPage.tsx<br/>(User Profile)"]:::minor-edit
    AppHeader["AppHeader.tsx<br/>(Navigation)"]:::context


    mainTsx -->|"wraps with<br/>AuthProvider"| App
    App --> StrawberryRiffApp
    mainTsx -.->|"imports"| AuthContext
    StrawberryRiffApp -->|"renders"| SignInPage
    StrawberryRiffApp -->|"renders"| MyRiffsPage
    StrawberryRiffApp -->|"renders"| AppHeader
    SignInPage -.->|"useAuth hook"| AuthContext
    MyRiffsPage -.->|"useAuth hook"| AuthContext
    AppHeader -.->|"useAuth hook"| AuthContext

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Local testing confirmed**: App loads successfully and navigation works without authentication context errors
- **Supabase dependency**: Console logs show Supabase client is not configured locally (missing env vars), but AuthProvider structure is correct
- **Breaking change**: This removes the mock authentication system entirely - ensure production environment has proper Supabase configuration
- **User interface migration**: Changed from custom `User` interface to Supabase's `User` type with different property structure

**Session Details:**
- Requested by: @LeSan321
- Link to Devin run: https://app.devin.ai/sessions/1c0ec4fe16da48e7934429dd2b6cbe30

**Screenshots:**
![App running successfully](file:///home/ubuntu/screenshots/localhost_5173_220405.png)
![Navigation working correctly](file:///home/ubuntu/screenshots/localhost_5173_220446.png)